### PR TITLE
target/basilisk: Set Cheshire dependency to tag

### DIFF
--- a/target/basilisk/deps/Bender.yml
+++ b/target/basilisk/deps/Bender.yml
@@ -11,4 +11,4 @@ package:
   name: dutctl_basilisk
 
 dependencies:
-  cheshire: { git: https://github.com/pulp-platform/cheshire, rev: paulsc/bas-test }
+  cheshire: { git: https://github.com/pulp-platform/cheshire, rev: bringup/basilisk }


### PR DESCRIPTION
When pushing the Basilisk example, I accidentally kept the dependency of Cheshire pointing to a volatile branch.

This fixes this mistake, pointing it to a proper tag.